### PR TITLE
Setup for CalmWave development

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration:
+
+eval "$(devbox generate direnv --print-envrc)"
+
+# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
+# for more details

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ erl_crash.dump
 /priv/plts/*.plt.hash
 /bench/graphs
 /bench/snapshots
+.devbox

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,14 @@
+{
+  "$schema":  "https://raw.githubusercontent.com/jetify-com/devbox/0.12.0/.schema/devbox.schema.json",
+  "packages": ["elixir@1.15.7"],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/devbox.json
+++ b/devbox.json
@@ -1,14 +1,10 @@
 {
-  "$schema":  "https://raw.githubusercontent.com/jetify-com/devbox/0.12.0/.schema/devbox.schema.json",
-  "packages": ["elixir@1.15.7"],
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.12.0/.schema/devbox.schema.json",
+  "packages": ["elixir@1.16.3"],
   "shell": {
-    "init_hook": [
-      "echo 'Welcome to devbox!' > /dev/null"
-    ],
+    "init_hook": ["echo 'Welcome to devbox!' > /dev/null"],
     "scripts": {
-      "test": [
-        "echo \"Error: no test specified\" && exit 1"
-      ]
+      "test": ["echo \"Error: no test specified\" && exit 1"]
     }
   }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,51 +1,51 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "elixir@1.15.7": {
-      "last_modified": "2024-03-23T13:32:18Z",
-      "resolved": "github:NixOS/nixpkgs/20bc93ca7b2158ebc99b8cef987a2173a81cde35#elixir",
+    "elixir@1.16.3": {
+      "last_modified": "2024-08-14T11:41:26Z",
+      "resolved": "github:NixOS/nixpkgs/0cb2fd7c59fed0cd82ef858cbcbdb552b9a33465#elixir",
       "source": "devbox-search",
-      "version": "1.15.7",
+      "version": "1.16.3",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/f2rm6pv5fciv9bb3vzq39yn5dzh8q05r-elixir-1.15.7",
+              "path": "/nix/store/ghlw3rpzmj8bxc18wyahs50gyvpnkdzj-elixir-1.16.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/f2rm6pv5fciv9bb3vzq39yn5dzh8q05r-elixir-1.15.7"
+          "store_path": "/nix/store/ghlw3rpzmj8bxc18wyahs50gyvpnkdzj-elixir-1.16.3"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/wkxcwxjxdz0lysd3yan1g9v1lc3f5q7z-elixir-1.15.7",
+              "path": "/nix/store/p5g1if1midansszw4raiax21xk6vnivy-elixir-1.16.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/wkxcwxjxdz0lysd3yan1g9v1lc3f5q7z-elixir-1.15.7"
+          "store_path": "/nix/store/p5g1if1midansszw4raiax21xk6vnivy-elixir-1.16.3"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ab2lfw3b8shzz1kgb8zcw8j5qx139qkb-elixir-1.15.7",
+              "path": "/nix/store/h742v6c6gv8iafpqx84gyyxgw3r0f68v-elixir-1.16.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ab2lfw3b8shzz1kgb8zcw8j5qx139qkb-elixir-1.15.7"
+          "store_path": "/nix/store/h742v6c6gv8iafpqx84gyyxgw3r0f68v-elixir-1.16.3"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/3ln5fzzdzczcyklibsp6jlffxzz00ng8-elixir-1.15.7",
+              "path": "/nix/store/mxr48y86anc2p6lgvfd9l0qq1d4csz2h-elixir-1.16.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/3ln5fzzdzczcyklibsp6jlffxzz00ng8-elixir-1.15.7"
+          "store_path": "/nix/store/mxr48y86anc2p6lgvfd9l0qq1d4csz2h-elixir-1.16.3"
         }
       }
     }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,53 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "elixir@1.15.7": {
+      "last_modified": "2024-03-23T13:32:18Z",
+      "resolved": "github:NixOS/nixpkgs/20bc93ca7b2158ebc99b8cef987a2173a81cde35#elixir",
+      "source": "devbox-search",
+      "version": "1.15.7",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/f2rm6pv5fciv9bb3vzq39yn5dzh8q05r-elixir-1.15.7",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/f2rm6pv5fciv9bb3vzq39yn5dzh8q05r-elixir-1.15.7"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wkxcwxjxdz0lysd3yan1g9v1lc3f5q7z-elixir-1.15.7",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/wkxcwxjxdz0lysd3yan1g9v1lc3f5q7z-elixir-1.15.7"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ab2lfw3b8shzz1kgb8zcw8j5qx139qkb-elixir-1.15.7",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ab2lfw3b8shzz1kgb8zcw8j5qx139qkb-elixir-1.15.7"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3ln5fzzdzczcyklibsp6jlffxzz00ng8-elixir-1.15.7",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3ln5fzzdzczcyklibsp6jlffxzz00ng8-elixir-1.15.7"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
1. devbox init
2. devbox add elixir@1.16.3
3. use direnv for loading devbox env

There is a .tool-versions but we got rid of asdf from our dev machines so setting this up instead in order to avoid each of us from having to setup asdf up on our machines again.